### PR TITLE
Fix installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://github.com/user-attachments/assets/76100d2e-4a1a-41ad-815c-816340ac6500
 Given a single image of a clothed person, **PSHuman** facilitates detailed geometry and realistic 3D human appearance across various poses within one minute.
 
 ### 📝 Update
-- __[2024.11.30]__: Release the SMPL-free [version](https://huggingface.co/pengHTYX/PSHuman_Unclip_768_6views), which does not requires SMPL condition for multview generation and perfome well in general posed human.
+- __[2024.11.30]__: Release the SMPL-free [version](https://huggingface.co/pengHTYX/PSHuman_Unclip_768_6views), which does not require SMPL condition for multiview generation and perform well in general posed human.
 
 
 ### Installation
@@ -23,11 +23,14 @@ conda activate pshuman
 # torch
 pip install torch==2.1.0 torchvision==0.16.0 torchaudio==2.1.0 --index-url https://download.pytorch.org/whl/cu121
 
-# other depedency
+# kaolin
+pip install kaolin==0.17.0 -f https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.0_cu121.html
+
+# other dependency
 pip install -r requirement.txt
 ```
 
-This project is also based on SMPLX. We borrowed the related models from [ECON](https://github.com/YuliangXiu/ECON) and [SIFU](https://github.com/River-Zhang/SIFU), and re-orginized them, which can be downloaded from [Onedrive](https://hkustconnect-my.sharepoint.com/:u:/g/personal/plibp_connect_ust_hk/EZQphP-2y5BGhEIe8jb03i4BIcqiJ2mUW2JmGC5s0VKOdw?e=qVzBBD). 
+This project is also based on SMPLX. We borrowed the related models from [ECON](https://github.com/YuliangXiu/ECON) and [SIFU](https://github.com/River-Zhang/SIFU), and re-organized them, which can be downloaded from [Onedrive](https://hkustconnect-my.sharepoint.com/:u:/g/personal/plibp_connect_ust_hk/EZQphP-2y5BGhEIe8jb03i4BIcqiJ2mUW2JmGC5s0VKOdw?e=qVzBBD). 
 
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,6 @@ jsonschema-specifications==2024.10.1
 jupyter_client==7.4.9
 jupyter_core==5.7.2
 jupyterlab_widgets==3.0.13
-kaolin==0.17.0
 kiwisolver==1.4.7
 kornia==0.7.4
 kornia_rs==0.1.7


### PR DESCRIPTION
I failed to install `kaolin==0.17.0` using `requirements.txt`

<img width="713" alt="image" src="https://github.com/user-attachments/assets/db74358f-6f5c-44ed-8775-c7bc8740fdd0">

Following the instructions of kaolin official repo, we can install it by:

```sh
pip install kaolin==0.17.0 -f https://nvidia-kaolin.s3.us-east-2.amazonaws.com/torch-2.1.0_cu121.html
```

Some typo fixes are also included in this PR.
